### PR TITLE
fix: specify UTF-8 explicitly when loading json

### DIFF
--- a/pytaxonomies/api.py
+++ b/pytaxonomies/api.py
@@ -270,7 +270,7 @@ class Taxonomies(abc.Mapping):  # type: ignore
             raise ImportError('jsonschema is required: pip install jsonschema')
         if sys.modules['pytaxonomies'].__file__:
             schema = os.path.join(os.path.abspath(os.path.dirname(sys.modules['pytaxonomies'].__file__)), 'data', 'misp-taxonomies', 'schema.json')
-            with open(schema, 'r') as f:
+            with open(schema, 'r', encoding="utf-8") as f:
                 loaded_schema = json.load(f)
             for t in self.values():
                 jsonschema.validate(t.taxonomy, loaded_schema)
@@ -278,7 +278,7 @@ class Taxonomies(abc.Mapping):  # type: ignore
     def __load_path(self, path: Union[Path, str]) -> Dict[str, Any]:
         if isinstance(path, str):
             path = Path(path)
-        with path.open('r') as f:
+        with path.open('r', encoding="utf-8") as f:
             return json.load(f)
 
     def __load_url(self, url: str) -> Dict[str, Any]:


### PR DESCRIPTION
### What changed
- Fixed #23 
- Specify UTF-8 explicitly when loading json

### Evidence
I have confirmed that it does not reproduce in the reproduction environment as follows.
```
C:\Users\fukusuke>python
Python 3.11.4 (tags/v3.11.4:d2340ef, Jun  7 2023, 05:45:37) [MSC v.1934 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from pytaxonomies import Taxonomies
>>> taxonomies = Taxonomies()
>>> print(list(taxonomies.get('enisa').keys()))
['physical-attack', 'unintentional-damage', 'disaster', 'failures-malfunction', 'outages', 'eavesdropping-interception-hijacking', 'legal', 'nefarious-activity-abuse']
>>>
```
I would appreciate it if you could review.
Regards,
